### PR TITLE
Fix port check

### DIFF
--- a/functions/anybar.fish
+++ b/functions/anybar.fish
@@ -1,6 +1,6 @@
 #!/usr/bin/env fish
 
 function anybar -a color -a port
-  [ -n "$PORT" ]; or set port 1738
+  [ -n "$port" ]; or set port 1738
   echo -n $color | nc -4u -w0 localhost $port
 end


### PR DESCRIPTION
I found that it wasn't possible to specify a different port to the default 1738, because the function tests for `$PORT` (all caps) and not `$port` (lowercase, matching the defined arg name). If you don't have $PORT defined in the environment, the `port` variable gets reset to the default 1738 no matter what it was supplied as.